### PR TITLE
Use terraform via dockerized binary

### DIFF
--- a/.env.secrets-template
+++ b/.env.secrets-template
@@ -1,0 +1,2 @@
+AWS_ACCESS_KEY_ID     = ""
+AWS_SECRET_ACCESS_KEY = ""

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -57,7 +57,8 @@ jobs:
       #   ${{ env.BACKEND_TFVARS }}
       # EOT
       run: > 
-        docker-compose run --rm terraform init 
+        docker-compose run --rm 
+        terraform init 
         -backend-config=bucket="${{ env.BUCKET }}" 
         -backend-config=key="${{ env.KEY }}" 
         -backend-config=region="${{ env.REGION }}" 
@@ -71,7 +72,17 @@ jobs:
 
     # Generate an execution plan for Terraform
     - name: Terraform Plan
-      run: docker-compose run --rm terraform plan -out=tfplan
+      run: >
+        docker-compose run --rm 
+        -e AWS_ACCESS_KEY_ID 
+        -e AWS_SECRET_ACCESS_KEY
+        -e TF_VAR_cf_username
+        -e TF_VAR_cf_password
+        -e TF_VAR_aws_access_key_id
+        -e TF_VAR_aws_secret_access_key
+        -e TF_VAR_gcp_credentials
+        -e TF_VAR_gcp_project
+        terraform plan -out=tfplan
 
       # On push to master, build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,7 +66,6 @@ jobs:
         -backend-config=encrypt="${{ env.ENCRYPT }}"
         -backend-config=access_key="${{ secrets.AWS_ACCESS_KEY_ID }}"
         -backend-config=secret_key="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-      # -backend-config=backend.tfvars
 
     # Check that all Terraform configuration files adhere to the canonical format
     - name: Terraform Format

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -45,6 +45,9 @@ jobs:
     # Install the latest version of the Terraform provider for Cloud Foundry (https://github.com/cloudfoundry-community/terraform-provider-cf/wiki)
     - name: Install the Cloud Foundry Terraform provider
       run: bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
+    # Supply a (empty) .env.secrets file
+    - name: Supply .env.secrets
+      run: touch .env.secrets
     # Initialize the Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       env:
@@ -60,7 +63,9 @@ jobs:
         -backend-config=bucket="${{ env.BUCKET }}" 
         -backend-config=key="${{ env.KEY }}" 
         -backend-config=region="${{ env.REGION }}" 
-        -backend-config=encrypt="${{ env.ENCRYPT }}" 
+        -backend-config=encrypt="${{ env.ENCRYPT }}"
+        -backend-config=access_key="${{ secrets.AWS_ACCESS_KEY_ID }}"
+        -backend-config=secret_key="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
       # -backend-config=backend.tfvars
 
     # Check that all Terraform configuration files adhere to the canonical format

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,46 +1,6 @@
-# This workflow installs the latest version of Terraform CLI and configures the Terraform CLI configuration file
-# with an API token for Terraform Cloud (app.terraform.io). On pull request events, this workflow will run
-# `terraform init`, `terraform fmt`, and `terraform plan` (speculative plan via Terraform Cloud). On push events
-# to the master branch, `terraform apply` will be executed.
-#
-# Documentation for `hashicorp/setup-terraform` is located here: https://github.com/hashicorp/setup-terraform
-#
-# To use this workflow, you will need to complete the following setup steps.
-#
-# 1. Create a `main.tf` file in the root of this repository with the `remote` backend and one or more resources defined.
-#   Example `main.tf`:
-#     # The configuration for the `remote` backend.
-#     terraform {
-#       backend "remote" {
-#         # The name of your Terraform Cloud organization.
-#         organization = "example-organization"
-#
-#         # The name of the Terraform Cloud workspace to store Terraform state files in.
-#         workspaces {
-#           name = "example-workspace"
-#         }
-#       }
-#     }
-#
-#     # An example resource that does nothing.
-#     resource "null_resource" "example" {
-#       triggers = {
-#         value = "A example resource that does nothing!"
-#       }
-#     }
-#
-#
-# 2. Generate a Terraform Cloud user API token and store it as a GitHub secret (e.g. TF_API_TOKEN) on this repository.
-#   Documentation:
-#     - https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html
-#     - https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
-#
-# 3. Reference the GitHub secret in step using the `hashicorp/setup-terraform` GitHub Action.
-#   Example:
-#     - name: Setup Terraform
-#       uses: hashicorp/setup-terraform@v1
-#       with:
-#         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+# On pull request events, this workflow will run `terraform init`, `terraform
+# fmt`, and `terraform plan`. On push events to the master branch, `terraform
+# apply` will be executed.
 
 name: 'Terraform'
 
@@ -82,15 +42,10 @@ jobs:
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/sb-0.1.0-rc.34-aws-0.0.1-rc.108/cloud-service-broker)
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/sb-0.1.0-rc.34-aws-0.0.1-rc.108/aws-services-0.0.1-rc.108.brokerpak)
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/sb-0.1.0-rc.34-gcp-0.0.1-rc.73/google-services-0.0.1-rc.73.brokerpak)
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
-      # with:
-      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
     # Install the latest version of the Terraform provider for Cloud Foundry (https://github.com/cloudfoundry-community/terraform-provider-cf/wiki)
-    - name: Install Unlisted Providers
+    - name: Install the Cloud Foundry Terraform provider
       run: bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    # Initialize the Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       env:
         BUCKET: "${{ secrets.BUCKET }}"
@@ -101,23 +56,23 @@ jobs:
       #   ${{ env.BACKEND_TFVARS }}
       # EOT
       run: > 
-        terraform init 
+        docker-compose run --rm terraform init 
         -backend-config=bucket="${{ env.BUCKET }}" 
         -backend-config=key="${{ env.KEY }}" 
         -backend-config=region="${{ env.REGION }}" 
         -backend-config=encrypt="${{ env.ENCRYPT }}" 
-      # -backend-config=
+      # -backend-config=backend.tfvars
 
-    # Checks that all Terraform configuration files adhere to a canonical format
+    # Check that all Terraform configuration files adhere to the canonical format
     - name: Terraform Format
-      run: terraform fmt -check
+      run: docker-compose run --rm terraform fmt -check
 
-    # Generates an execution plan for Terraform
+    # Generate an execution plan for Terraform
     - name: Terraform Plan
-      run: terraform plan -out=tfplan
+      run: docker-compose run --rm terraform plan -out=tfplan
 
       # On push to master, build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Apply
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-      run: terraform apply tfplan
+      run: docker-compose run --rm terraform apply tfplan

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,9 +42,7 @@ jobs:
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/sb-0.1.0-rc.34-aws-0.0.1-rc.108/cloud-service-broker)
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/sb-0.1.0-rc.34-aws-0.0.1-rc.108/aws-services-0.0.1-rc.108.brokerpak)
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/sb-0.1.0-rc.34-gcp-0.0.1-rc.73/google-services-0.0.1-rc.73.brokerpak)
-    # Install the latest version of the Terraform provider for Cloud Foundry (https://github.com/cloudfoundry-community/terraform-provider-cf/wiki)
-    - name: Install the Cloud Foundry Terraform provider
-      run: bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"
+        chmod +x app/cloud-service-broker
     # Supply a (empty) .env.secrets file
     - name: Supply .env.secrets
       run: touch .env.secrets

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ app/config.yml
 app.zip
 app/*
 backend.tfvars
+.env.secrets

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ provisioned, bound, unbound, and unprovisioned.
 ## Dependencies
 
 The broker deployment is specified and managed using
-[Terraform](https://www.terraform.io/). You must have at least Terraform version
-`0.12.6` installed.
+[Docker](https://www.docker.com/products/docker-desktop).
 
 You must also [install the Terraform provider for Cloud
 Foundry](https://github.com/cloudfoundry-community/terraform-provider-cf/wiki#using-the-provider)
@@ -67,10 +66,16 @@ github_release and github_actions_secret in the github_provider!) -->
 
     ```
 
-1. Copy the `backend.tfvars-template` and edit in the values for the S3 bucket.
+1. Copy the `backend.tfvars-template` and edit in the non-sensitive values for the S3 bucket.
     ```
     cp backend.tfvars-template backend.tfvars
-    ${EDITOR} terraform.tfvars
+    ${EDITOR} backend.tfvars
+    ```
+
+1. Copy the `.env.secrets-template` and edit in the sensitive values for the S3 bucket.
+    ```
+    cp .env.secrets-template .env.secrets
+    ${EDITOR} .env.secrets
     ```
 
 1. Copy the `terraform.tfvars-template` and edit in the values for the Cloud
@@ -80,20 +85,19 @@ github_release and github_actions_secret in the github_provider!) -->
     ${EDITOR} terraform.tfvars
     ```
 
-1. Run Terraform init to set up the backend. You must provide the credentials
-   for the S3 bucket as environment variables.
+1. Run Terraform init to set up the backend.
     ```
-    AWS_ACCESS_KEY_ID="[redacted]" AWS_SECRET_ACCESS_KEY="[redacted]]" terraform init -backend-config=backend.tfvars
+    docker-compose run --rm terraform init
     ```
 1. Run Terraform apply and answer `yes` when prompted.
     ```
-    AWS_ACCESS_KEY_ID="[redacted]" AWS_SECRET_ACCESS_KEY="[redacted]]" terraform apply
+    docker-compose run --rm terraform apply
     ```
 
 # Uninstalling and deleting the broker
 Run Terraform destroy and answer `yes` when prompted.
 ```
-AWS_ACCESS_KEY_ID="[redacted]" AWS_SECRET_ACCESS_KEY="[redacted]]" terraform destroy
+docker-compose run --rm terraform destroy
 ```
 
 # Continuously deploying the broker
@@ -105,7 +109,7 @@ following into [the `Settings > Secrets` page](/settings/secrets) on your fork:
 | Secret Name | Description |
 |-------------|-------------|
 | AWS_ACCESS_KEY_ID | the S3 bucket key|
-| AWS_SECRET_ACCESS_KEY | the S3 bucket  |
+| AWS_SECRET_ACCESS_KEY | the S3 bucket secret |
 | BUCKET | the S3 bucket name |
 | TF_VAR_AWS_ACCESS_KEY_ID | the key for brokering resources in AWS |
 | TF_VAR_AWS_SECRET_ACCESS_KEY | the secret for brokering resources in AWS |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ github_release and github_actions_secret in the github_provider!) -->
 
 1. Run Terraform init to set up the backend.
     ```
-    docker-compose run --rm terraform init
+    docker-compose run --rm terraform init -backend-config=backend.tfvars
     ```
 1. Run Terraform apply and answer `yes` when prompted.
     ```

--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ provisioned, bound, unbound, and unprovisioned.
 The broker deployment is specified and managed using
 [Docker](https://www.docker.com/products/docker-desktop).
 
-You must also [install the Terraform provider for Cloud
-Foundry](https://github.com/cloudfoundry-community/terraform-provider-cf/wiki#using-the-provider)
-```
-bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)
-```
-
 ## Creating and installing the broker
 <!-- (TODO
 Try to do this automatically with terraform... It seems possible with

--- a/backend.tfvars-template
+++ b/backend.tfvars-template
@@ -2,9 +2,3 @@ bucket                = "<bucket>"
 region                = "<region>"
 key                   = "ssb-tfstate"
 encrypt               = true
-
-# Note the following will be ignored due to a bug...
-# https://github.com/hashicorp/terraform/issues/25649
-# Until it's fixed you must supply these values as env vars.
-AWS_ACCESS_KEY_ID     = "<key_id"
-AWS_SECRET_ACCESS_KEY = "<secret_key>"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,5 @@ services:
     volumes:
       - .:/code
     working_dir: /code
-    environment:
-      TF_CLI_ARGS_init: -backend-config=backend.tfvars
     env_file:
     - .env.secrets

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,10 @@ version: '3.7'
 
 services:
   terraform:
-    image: hashicorp/terraform:0.12.29
+    build: docker
     volumes:
       - .:/code
     working_dir: /code
     env_file:
     - .env.secrets
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.7'
+
+services:
+  terraform:
+    image: hashicorp/terraform:0.12.29
+    volumes:
+      - .:/code
+    working_dir: /code
+    environment:
+      TF_CLI_ARGS_init: -backend-config=backend.tfvars
+    env_file:
+    - .env.secrets

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM hashicorp/terraform:0.12.29
+RUN apk add curl bash
+RUN bash -c "$(curl -fsSL https://raw.github.com/cloudfoundry-community/terraform-provider-cf/master/bin/install.sh)"


### PR DESCRIPTION
Use terraform via a Docker container so that there's no potential for drift between developers, and between developers and the GitHub Action.