### PR TITLE
Fix missing vars during apply

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -127,4 +127,13 @@ jobs:
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Apply
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-      run: docker-compose run --rm terraform apply -auto-approve
+      run: docker-compose run --rm \
+        -e AWS_ACCESS_KEY_ID  \
+        -e AWS_SECRET_ACCESS_KEY \
+        -e TF_VAR_cf_username \
+        -e TF_VAR_cf_password \
+        -e TF_VAR_aws_access_key_id \
+        -e TF_VAR_aws_secret_access_key \
+        -e TF_VAR_gcp_credentials \
+        -e TF_VAR_gcp_project \
+        terraform apply -auto-approve


### PR DESCRIPTION
Now that we're no longer applying a `tfplan` file from the `plan` step, we need to explicitly make the variables available during `terraform apply`.