### PR TITLE
Include the EKS brokerpak

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,6 +42,7 @@ jobs:
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/v0.8.3-beta/cloud-service-broker)
         (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/v0.8.3-beta/aws-services-1.1.0-rc.2.brokerpak)
         (cd app && curl -L -O https://github.com/GSA/datagov-brokerpak/releases/download/v0.6.0/datagov-services-pak-1.0.0.brokerpak)
+        (cd app && curl -L -O https://github.com/GSA/eks-brokerpak/releases/download/v0.5.0/eks-services-pack-1.0.0.brokerpak)
         chmod +x app/cloud-service-broker
     # Supply a (empty) .env.secrets file
     - name: Supply .env.secrets

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ github_release and github_actions_secret in the github_provider!) -->
     (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/v0.8.3-beta/cloud-service-broker)
     (cd app && curl -L -O https://github.com/pivotal/cloud-service-broker/releases/download/v0.8.3-beta/aws-services-1.1.0-rc.2.brokerpak)
     (cd app && curl -L -O https://github.com/GSA/datagov-brokerpak/releases/download/v0.6.0/datagov-services-pak-1.0.0.brokerpak)
+    (cd app && curl -L -O https://github.com/GSA/eks-brokerpak/releases/download/v0.5.0/eks-services-pack-1.0.0.brokerpak)
     chmod +x app/cloud-service-broker
     ```
 


### PR DESCRIPTION
This change adds the [eks-brokerpak](https://github.com/GSA/eks-brokerpak) to our deployment, which enables brokering of EKS clusters through cloud.gov.