### PR TITLE
Support superusers for postgresql and update EKS brokerpak

### DIFF
--- a/app-setup.sh
+++ b/app-setup.sh
@@ -31,7 +31,10 @@ chmod +x app/.profile
 # Note the datagov-brokerpak filename isn't parameterized... It doesn't match
 # the release name upstream yet.
 (cd app && curl -f -LO https://github.com/GSA/datagov-brokerpak/releases/download/v${DATAGOV_BROKERPAK_VERSION}/datagov-services-pak-1.0.0.brokerpak)
-(cd app && curl -f -LO https://github.com/adborden/csb-brokerpak-aws/releases/download/v${AWS_BROKERPAK_VERSION}/aws-services-${AWS_BROKERPAK_VERSION}.brokerpak)
+
+# Temporarily use Aaron's fork
+# (cd app && curl -f -LO https://github.com/adborden/csb-brokerpak-aws/releases/download/v${AWS_BROKERPAK_VERSION}/aws-services-${AWS_BROKERPAK_VERSION}.brokerpak)
+(cd app && curl -f -LO https://github.com/adborden/csb-brokerpak-aws/releases/download/v0.1.0-gsa/aws-services-0.1.0.brokerpak)
 
 # Install the Helm binary
 curl -f -L ${BASE_URL}/${TAR_FILE} |tar xvz && \

--- a/app-setup.sh
+++ b/app-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-AWS_BROKERPAK_VERSION="1.1.0-rc.5"
+AWS_BROKERPAK_VERSION="v0.1.0-gsa" # 1.1.0-rc5
 EKS_BROKERPAK_VERSION="0.15.0"
 DATAGOV_BROKERPAK_VERSION="0.10.0"
 
@@ -31,7 +31,7 @@ chmod +x app/.profile
 # Note the datagov-brokerpak filename isn't parameterized... It doesn't match
 # the release name upstream yet.
 (cd app && curl -f -LO https://github.com/GSA/datagov-brokerpak/releases/download/v${DATAGOV_BROKERPAK_VERSION}/datagov-services-pak-1.0.0.brokerpak)
-(cd app && curl -f -LO https://github.com/cloudfoundry-incubator/csb-brokerpak-aws/releases/download/${AWS_BROKERPAK_VERSION}/aws-services-${AWS_BROKERPAK_VERSION}.brokerpak)
+(cd app && curl -f -LO https://github.com/adborden/csb-brokerpak-aws/releases/download/${AWS_BROKERPAK_VERSION}/aws-services-${AWS_BROKERPAK_VERSION}.brokerpak)
 
 # Install the Helm binary
 curl -f -L ${BASE_URL}/${TAR_FILE} |tar xvz && \

--- a/app-setup.sh
+++ b/app-setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-AWS_BROKERPAK_VERSION="v0.1.0-gsa" # 1.1.0-rc5
-EKS_BROKERPAK_VERSION="0.15.0"
+AWS_BROKERPAK_VERSION="0.1.0-gsa" # 1.1.0-rc5
+EKS_BROKERPAK_VERSION="0.16.0"
 DATAGOV_BROKERPAK_VERSION="0.10.0"
 
 # TODO: Check sha256 sums
@@ -31,7 +31,7 @@ chmod +x app/.profile
 # Note the datagov-brokerpak filename isn't parameterized... It doesn't match
 # the release name upstream yet.
 (cd app && curl -f -LO https://github.com/GSA/datagov-brokerpak/releases/download/v${DATAGOV_BROKERPAK_VERSION}/datagov-services-pak-1.0.0.brokerpak)
-(cd app && curl -f -LO https://github.com/adborden/csb-brokerpak-aws/releases/download/${AWS_BROKERPAK_VERSION}/aws-services-${AWS_BROKERPAK_VERSION}.brokerpak)
+(cd app && curl -f -LO https://github.com/adborden/csb-brokerpak-aws/releases/download/v${AWS_BROKERPAK_VERSION}/aws-services-${AWS_BROKERPAK_VERSION}.brokerpak)
 
 # Install the Helm binary
 curl -f -L ${BASE_URL}/${TAR_FILE} |tar xvz && \


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2604

Use a fork of the AWS brokerpak to support superuser roles, allowing
installation of postgresql extensions.