### PR TITLE
SSB application attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,9 +57,9 @@ resource "cloudfoundry_app" "ssb" {
   path             = "./app.zip"
   buildpack        = "binary_buildpack"
   command          = "source .profile && ./cloud-service-broker serve"
-  instances        = 2
-  memory           = 512
-  disk_quota       = 2048
+  instances        = var.ssb_app_instances
+  memory           = var.ssb_app_memory
+  disk_quota       = var.ssb_app_disk_quota
   enable_ssh       = false
   source_code_hash = data.archive_file.app_zip.output_base64sha256
   strategy         = "blue-green"

--- a/vars.tf
+++ b/vars.tf
@@ -44,3 +44,17 @@ variable "client_spaces" {
   }
 }
 
+variable "ssb_app_disk_quota" {
+  default     = 2048
+  description = "Disk quota (MiB) to allocate for ssb application."
+}
+
+variable "ssb_app_instances" {
+  default     = 1
+  description = "Number of application instances to run."
+}
+
+variable "ssb_app_memory" {
+  default     = 256
+  description = "Memory (MiB) to allocate for ssb application."
+}


### PR DESCRIPTION
Allow us to assign different attributes per environment.

Default to a single instance of the SSB application.