### PR TITLE
Update the location of the solr-operator Helm chart

### DIFF
--- a/app-setup-eks.sh
+++ b/app-setup-eks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-EKS_BROKERPAK_VERSION="0.20.0"
+EKS_BROKERPAK_VERSION="0.21.0"
 
 # TODO: Check sha256 sums
 HELM_VERSION="3.2.1"


### PR DESCRIPTION
Does this by grabbing the latest brokerpak.

Merge this one after [this PR on the brokerpak](https://github.com/GSA/eks-brokerpak/pull/34) is merged.