### PR TITLE
Increase creation timeout for ssb-k8s service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "cloudfoundry_service_instance" "k8s_cluster" {
   service_plan = module.broker_eks.plans["aws-eks-service/raw"]
   tags         = ["k8s"]
   timeouts {
-    create = "30m"
+    create = "40m"
     delete = "30m"
   }
 }


### PR DESCRIPTION
I saw the last creation time was 28m, which is cutting it too close!

(Note that I've just done a `terraform apply` outside GitHub Actions in the management-staging space, so the plan for the staging environment may be nothing.)