### PR TITLE
Use /dev/shm (a tmpfs) for any terraform workspace files

### DIFF
--- a/broker/main.tf
+++ b/broker/main.tf
@@ -58,7 +58,8 @@ resource "cloudfoundry_app" "ssb" {
     DB_TLS                                   = "skip-verify",
     GSB_COMPATIBILITY_ENABLE_CATALOG_SCHEMAS = true,
     GSB_COMPATIBILITY_ENABLE_CF_SHARING      = true,
-    AWS_ZONE                                 = var.aws_zone
+    AWS_ZONE                                 = var.aws_zone,
+    TMPDIR                                   = "/dev/shm",
   }
 
   routes {


### PR DESCRIPTION
We don't want .tfstate to be on disk unencrypted