### PR TITLE
Revert "Use /dev/shm (a tmpfs) for any terraform workspace files"

### DIFF
--- a/app-setup-aws.sh
+++ b/app-setup-aws.sh
@@ -11,9 +11,6 @@ mkdir -p app-aws/bin
 cat > app-aws/.profile << 'EOF'
 # Locate additional binaries needed by the deployed brokerpaks
 export PATH="$PATH:${PWD}/bin"
-
-# Use a tmpfs while working with Terraform state
-export TMPDIR="/dev/shm"
 EOF
 chmod +x app-aws/.profile
 

--- a/app-setup-eks.sh
+++ b/app-setup-eks.sh
@@ -21,9 +21,6 @@ mkdir -p app-eks/bin
 cat > app-eks/.profile << 'EOF'
 # Locate additional binaries needed by the deployed brokerpaks
 export PATH="$PATH:${PWD}/bin"
-
-# Use a tmpfs while working with Terraform state
-export TMPDIR="/dev/shm"
 EOF
 chmod +x app-eks/.profile
 

--- a/app-setup-solr.sh
+++ b/app-setup-solr.sh
@@ -20,9 +20,6 @@ cat > app-solr/.profile << 'EOF'
 # Locate additional binaries needed by the deployed brokerpaks
 export PATH="$PATH:${PWD}/bin"
 
-# Use a tmpfs while working with Terraform state
-export TMPDIR="/dev/shm"
-
 # Export credentials for the k8s cluster and namespace where the Solr brokerpak
 # should manage instances of SolrCloud. We get these from the binding directly.
 export SOLR_SERVER=$(echo $VCAP_SERVICES | jq -r '.["aws-eks-service"][] | .credentials.server')

--- a/broker/main.tf
+++ b/broker/main.tf
@@ -58,7 +58,7 @@ resource "cloudfoundry_app" "ssb" {
     DB_TLS                                   = "skip-verify",
     GSB_COMPATIBILITY_ENABLE_CATALOG_SCHEMAS = true,
     GSB_COMPATIBILITY_ENABLE_CF_SHARING      = true,
-    AWS_ZONE                                 = var.aws_zone,
+    AWS_ZONE                                 = var.aws_zone
   }
 
   routes {


### PR DESCRIPTION
This reverts commits:
- 6953e4cf2ff273fce092cfadb8dff6de241dabba
- f57de9aa73da3debaa6da1c0b50ebbb8be1e08cf

There's not enough memory to store the several gigabyte sized brokerpaks in
/dev/shm. Cloud.gov provides encrypted storage for application instances.