### PR TITLE
Deploy EKS brokerpak 0.27.0

### DIFF
--- a/app-setup-eks.sh
+++ b/app-setup-eks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-EKS_BROKERPAK_VERSION="v0.26.0"
+EKS_BROKERPAK_VERSION="v0.27.0"
 
 # TODO: Check sha256 sums
 HELM_VERSION="3.2.1"

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "cloudfoundry_service_instance" "k8s_cluster" {
   space        = data.cloudfoundry_space.broker_space.id
   service_plan = module.broker_eks.plans["aws-eks-service/raw"]
   tags         = ["k8s"]
+  json_params  = "{ \"cluster_name\": \"k8s-brokered\" }"
   timeouts {
     create = "40m"
     delete = "30m"


### PR DESCRIPTION
This PR bumps the EKS brokerpak release version to be deployed. Tests will pass once 0.27.0 of the EKS brokerpak is tagged and released.

 **It also adds configuration needed to give the Solr-hosting k8s deployment stable URLs.**