### PR TITLE
Deploy EKS brokerpak 0.29.0

### DIFF
--- a/app-setup-eks.sh
+++ b/app-setup-eks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-EKS_BROKERPAK_VERSION="v0.26.0"
+EKS_BROKERPAK_VERSION="v0.29.0"
 
 # TODO: Check sha256 sums
 HELM_VERSION="3.2.1"


### PR DESCRIPTION
This PR bumps the EKS brokerpak release version to be deployed. Tests will pass once 0.29.0 of the EKS brokerpak is tagged and released.