### PR TITLE
Extend timeout for k8s update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ resource "cloudfoundry_service_instance" "k8s_cluster" {
   json_params  = "{ \"cluster_name\": \"k8s-brokered\" }"
   timeouts {
     create = "40m"
+    update = "90m" # in case of an EKS destroy/create
     delete = "30m"
   }
 }


### PR DESCRIPTION
In some cases where a change might require a destroy+create on the back end, use
a long timeout to allow for that.
