### PR TITLE
Automate management of AWS users and roles

### DIFF
--- a/.env.secrets-template
+++ b/.env.secrets-template
@@ -1,4 +1,4 @@
-TF_VAR_AWS_ACCESS_KEY_ID=""
-TF_VAR_AWS_SECRET_ACCESS_KEY=""
-TF_VAR_CF_PASSWORD=""
-TF_VAR_CF_USERNAME=""
+TF_VAR_aws_access_key_id=""
+TF_VAR_aws_secret_access_key=""
+TF_VAR_cf_password=""
+TF_VAR_cf_username=""

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ app-smtp
 app-eks
 app-solr
 app-ssb-*.zip
+.backend.secrets

--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,9 @@ override.tf.json
 .DS_Store
 /todo.txt
 terraform.tfvars
-app/config.yml
-app.zip
-app/*
 backend.tfvars
 .env.secrets
-app-aws
+app-smtp
 app-eks
 app-solr
+app-ssb-*.zip

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,23 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
-  version     = "0.14.0"
+  version     = "0.14.2"
   constraints = "~> 0.14.0"
   hashes = [
-    "h1:S/KPiksTFFtV1HZOv6Th7DtVdfo4TC+STSjkw73Rtvo=",
-    "zh:037ee37aa79853f5c9126c1861935e2605751e124c298abc3c7ac407fecb0624",
-    "zh:2c34baa168edc509c5d994949365cb746defd192191f8b7e5ddd77d4bc97feb4",
-    "zh:45a5759828c3952dc4ab0e78096e563b24661fd53db573d8bf5e7563cccf86a7",
-    "zh:5e0368328d01e702083d102daf0e5cb76a90f44e6c54f15cadb7fbd61e2b3424",
-    "zh:602963f333848c1591ed53b1a4c13fce30d1ff1af3238ee3263ee560abba2639",
-    "zh:6084398da5588442b443263475631ed1426256ae4152ce613234bb4c87bcd1b9",
-    "zh:60c62502c475a2db12e89aec65e7203715e867346129ab3e8ff8741fa1eb7c9f",
-    "zh:9b0ef238238bd9db5f335a3150d3290662fb86d0034b33a3ce6a08f38ef727c3",
-    "zh:dec00b544d8af0d99a63a3836b2f8dfc93592a1dd16501b63f55f23d0524514d",
-    "zh:dfad150ddb3a908028da060e5f8798694da0d06dd8bbae6d3e33d2ccbd1c93a7",
-    "zh:f7dde19e747e536df6c889e17024e5402626263e17a1a68032cf3a2ebd3ac39a",
-    "zh:fae11e09d3a2e111ad4d93ecce804abdabaa30fa97fdd4bca5f4cd0512490f34",
-    "zh:fbb55598ea9d3397acd69e3a72f616a38e4beba642921965fcace9dd4cfbd031",
+    "h1:WlfTIO7Zrd64R7zyMBLpgioiUKufT0aIFpfcI0uec7g=",
+    "zh:0a8184b3bb0b5d8934c1f9e988fcf0da13ce05f666d6b7861cf50b74496e5a23",
+    "zh:0afa174665bdd728e7a9951952a0ef91526677f9b8c57250e210e696ec84c861",
+    "zh:0dfdd0288641dcecd5d9c894546163b51fbd2f576a83c5013f82dbf86067a8c1",
+    "zh:310c32a75986e797525b89ae41a45021bd64ee46858c7e68f4504c763440da19",
+    "zh:5d99fbedaddfe12830efec6b2387552d1ea10bda22596fcd46bc75994cdfd4b5",
+    "zh:60ecd53ec4e6795f0392d8701015a6efefb0446174ad20cbe2cdc0ca9f984a9e",
+    "zh:6763498656278a703b6045ab401ebf55346341d8891c2a70c7916585b6577f33",
+    "zh:7aa63f571c434dd2cd76a7fd7140a928eb10e1f629c93627a0afd8c1c78d6808",
+    "zh:8dec45aa1705272975958a859dd53960638816d0ea793c671715c9c1a353b2d0",
+    "zh:957db10a90ae964c9ed05c2653d44e738beac61239e4a57c7c47378eba33dff7",
+    "zh:9effa3a98bcdf39f2db2be56ac34b2b901ca78740acc9f317c9a3e757a0f76b1",
+    "zh:a3c4d51590bce8fccc504c7e357b322a12702180c92a4d682d269983df29765a",
+    "zh:b11b17166836f86a5bca92a2776ba6ef57de0298072bd8c677c82744361d57cb",
+    "zh:c4a338ff3f5bf9514c64c6c0aa7883c43d14920b84d1faa54876ffd722bfc434",
+    "zh:fa9191416e2d73e3aaa835eb04643e179bf0f4d9d97fd3f03088e3a989606543",
   ]
 }
 
@@ -26,6 +28,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.0.0"
   constraints = "~> 2.0.0"
   hashes = [
+    "h1:WWGcM4hCkZLObytvhPHxR/s6FR7+jhNHGQ+2DYvBKbI=",
     "h1:eOUi4EO4QTgPuz+gmD8xy2LTTxNfyc9txyc9PDARth8=",
     "zh:1c3300a6686481ed0b3ce456949805b5c55f901b77108543046f12118a102914",
     "zh:2d44bcc8a5ea3f2c2ff54ca4c4b273cdc3500ad8bb6929eec6722bb9d10a9714",
@@ -41,22 +44,21 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.70.0"
-  constraints = "~> 2.67"
+  version     = "3.53.0"
+  constraints = ">= 2.23.0, >= 2.50.0, >= 3.35.0, ~> 3.35"
   hashes = [
-    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
-    "zh:01a5f351146434b418f9ff8d8cc956ddc801110f1cc8b139e01be2ff8c544605",
-    "zh:1ec08abbaf09e3e0547511d48f77a1e2c89face2d55886b23f643011c76cb247",
-    "zh:606d134fef7c1357c9d155aadbee6826bc22bc0115b6291d483bc1444291c3e1",
-    "zh:67e31a71a5ecbbc96a1a6708c9cc300bbfe921c322320cdbb95b9002026387e1",
-    "zh:75aa59ae6f0834ed7142c81569182a658e4c22724a34db5d10f7545857d8db0c",
-    "zh:76880f29fca7a0a3ff1caef31d245af2fb12a40709d67262e099bc22d039a51d",
-    "zh:aaeaf97ffc1f76714e68bc0242c7407484c783d604584c04ad0b267b6812b6dc",
-    "zh:ae1f88d19cc85b2e9b6ef71994134d55ef7830fd02f1f3c58c0b3f2b90e8b337",
-    "zh:b155bdda487461e7b3d6e3a8d5ce5c887a047e4d983512e81e2c8266009f2a1f",
-    "zh:ba394a7c391a26c4a91da63ad680e83bde0bc1ecc0a0856e26e9d62a4e77c408",
-    "zh:e243c9d91feb0979638f28eb26f89ebadc179c57a2bd299b5729fb52bd1902f2",
-    "zh:f6c05e20d9a3fba76ca5f47206dde35e5b43b6821c6cbf57186164ce27ba9f15",
+    "h1:oRCCzfwGCDNyuhIJ8kCg0N7h4W2WESm37o2GIt0ETpQ=",
+    "zh:35a77c79170b0cf3fb7eb835f3ce0b715aeeceda0a259e96e49fed5a30cf6646",
+    "zh:519d5470a932b1ec9a0fe08876c5e0f0f84f8e506b652c051e4ab708be081e89",
+    "zh:58cfa5b454602d57c47acd15c2ad166a012574742cdbcf950787ce79b6510218",
+    "zh:5fc3c0162335a730701c0175809250233f45f1021da8fa52c73635e4c08372d8",
+    "zh:6790f9d6261eb4bd5cdd7cd9125f103befce2ba127f9ba46eef83585b86e1d11",
+    "zh:76e1776c3bf9568d520f78419ec143c081f653b8df4fb22577a8c4a35d3315f9",
+    "zh:ca8ed88d0385e45c35223ace59b1bf77d81cd2154d5416e63a3dddaf0def30e6",
+    "zh:d002562c4a89a9f1f6cd8d854fad3c66839626fc260e5dde5267f6d34dbd97a4",
+    "zh:da5e47fb769e90a2f16c90fd0ba95d62da3d76eb006823664a5c6e96188731b0",
+    "zh:dfe7f33ec252ea550e090975a5f10940c27302bebb5559957957937b069646ea",
+    "zh:fa91574605ddce726e8a4e421297009a9dabe023106e139ac46da49c8285f2fe",
   ]
 }
 
@@ -65,6 +67,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.0.0"
   hashes = [
     "h1:0QaSbRBgBi8vI/8IRwec1INdOqBxXbgsSFElx1O4k4g=",
+    "h1:SzM8nt2wzLMI28A3CWAtW25g3ZCm1O4xD0h3Ps/rU1U=",
     "zh:0d4f683868324af056a9eb2b06306feef7c202c88dbbe6a4ad7517146a22fb50",
     "zh:4824b3c7914b77d41dfe90f6f333c7ac9860afb83e2a344d91fbe46e5dfbec26",
     "zh:4b82e43712f3cf0d0cbc95b2cbcd409ba8f0dc7848fdfb7c13633c27468ed04a",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ github_release and github_actions_secret in the github_provider!) -->
 
     ```bash
     ./app-setup-eks.sh
+    ./app-setup-smtp.sh
     ./app-setup-solr.sh
     ```
 
@@ -100,13 +101,13 @@ github_release and github_actions_secret in the github_provider!) -->
 1. Run Terraform init to set up the backend.
 
     ```bash
-    docker-compose run --rm --env-file=.backend.secrets terraform init -backend-config=backend.tfvars
+    docker-compose --env-file .backend.secrets run --rm terraform init -backend-config backend.tfvars
     ```
 
 1. Run Terraform apply, review the plan, and answer `yes` when prompted.
 
     ```bash
-    docker-compose run --rm --env-file=.env.secrets terraform apply
+    docker-compose --env-file=.env.secrets run --rm terraform apply
     ```
 
 ## Uninstalling and deleting the broker

--- a/application-boundary.tf
+++ b/application-boundary.tf
@@ -28,8 +28,8 @@ module "broker_smtp" {
   broker_space          = var.broker_space
   client_spaces         = var.client_spaces
   enable_ssh            = var.enable_ssh
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
+  aws_access_key_id     = module.ssb-smtp-broker-user.iam_access_key_id
+  aws_secret_access_key = module.ssb-smtp-broker-user.iam_access_key_secret
   aws_zone              = var.broker_zone
   depends_on = [
     aws_route53_zone.zone

--- a/application-boundary.tf
+++ b/application-boundary.tf
@@ -12,8 +12,8 @@ module "broker_eks" {
   client_spaces         = var.client_spaces
   enable_ssh            = var.enable_ssh
   memory                = 512
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
+  aws_access_key_id     = module.ssb-eks-broker-user.iam_access_key_id
+  aws_secret_access_key = module.ssb-eks-broker-user.iam_access_key_secret
   aws_zone              = var.broker_zone
   depends_on = [
     aws_route53_zone.zone

--- a/application-boundary.tf
+++ b/application-boundary.tf
@@ -1,27 +1,6 @@
-resource "aws_route53_zone" "zone" {
-  count = var.manage_zone ? 1 : 0
-  name  = var.broker_zone
-}
-
 data "cloudfoundry_space" "broker_space" {
   name     = var.broker_space.space
   org_name = var.broker_space.org
-}
-
-resource "aws_servicequotas_service_quota" "minimum_quotas" {
-  for_each = {
-    "vpc/L-45FE3B85" = 20 # egress-only internet gateways per region
-    "vpc/L-A4707A72" = 20 # internet gateways per region
-    "vpc/L-FE5A380F" = 20 # NAT gateways per AZ
-    "vpc/L-2AFB9258" = 16 # security groups per network interface (16 is the max)
-    "vpc/L-F678F1CE" = 20 # VPCs per region
-    "eks/L-33415657" = 20 # Fargate profiles per cluster
-    "eks/L-23414FF3" = 10 # label pairs per Fargate profile selector
-    "ec2/L-0263D0A3" = 20 # EC2-VPC Elastic IPs
-  }
-  service_code = element(split("/", each.key), 0)
-  quota_code   = element(split("/", each.key), 1)
-  value        = each.value
 }
 
 module "broker_eks" {
@@ -39,17 +18,6 @@ module "broker_eks" {
   depends_on = [
     aws_route53_zone.zone
   ]
-}
-
-module "broker_solr" {
-  source = "./broker"
-
-  name          = "ssb-solr"
-  path          = "./app-solr"
-  broker_space  = var.broker_space
-  client_spaces = var.client_spaces
-  enable_ssh    = var.enable_ssh
-  services      = [cloudfoundry_service_instance.k8s_cluster.id]
 }
 
 module "broker_smtp" {
@@ -80,4 +48,15 @@ resource "cloudfoundry_service_instance" "k8s_cluster" {
     update = "90m" # in case of an EKS destroy/create
     delete = "30m"
   }
+}
+
+module "broker_solr" {
+  source = "./broker"
+
+  name          = "ssb-solr"
+  path          = "./app-solr"
+  broker_space  = var.broker_space
+  client_spaces = var.client_spaces
+  enable_ssh    = var.enable_ssh
+  services      = [cloudfoundry_service_instance.k8s_cluster.id]
 }

--- a/application-boundary.tf
+++ b/application-boundary.tf
@@ -48,6 +48,10 @@ resource "cloudfoundry_service_instance" "k8s_cluster" {
     update = "90m" # in case of an EKS destroy/create
     delete = "30m"
   }
+  depends_on = [
+    module.broker_eks
+  ]
+
 }
 
 module "broker_solr" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,8 +7,11 @@ services:
       - .:/code
     working_dir: /code
     environment:
+      # Terraform backend bucket creds
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      
+      # Secrets for the appropriate Terraform workspace
       - TF_VAR_aws_access_key_id
       - TF_VAR_aws_secret_access_key
       - TF_VAR_cf_username

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,4 +6,10 @@ services:
     volumes:
       - .:/code
     working_dir: /code
-
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - TF_VAR_aws_access_key_id
+      - TF_VAR_aws_secret_access_key
+      - TF_VAR_cf_username
+      - TF_VAR_cf_password

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   terraform:
-    image: hashicorp/terraform:0.14.3
+    image: hashicorp/terraform:1.0.4
     volumes:
       - .:/code
     working_dir: /code

--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -1,0 +1,21 @@
+resource "aws_servicequotas_service_quota" "minimum_quotas" {
+  for_each = {
+    "vpc/L-45FE3B85" = 20 # egress-only internet gateways per region
+    "vpc/L-A4707A72" = 20 # internet gateways per region
+    "vpc/L-FE5A380F" = 20 # NAT gateways per AZ
+    "vpc/L-2AFB9258" = 16 # security groups per network interface (16 is the max)
+    "vpc/L-F678F1CE" = 20 # VPCs per region
+    "eks/L-33415657" = 20 # Fargate profiles per cluster
+    "eks/L-23414FF3" = 10 # label pairs per Fargate profile selector
+    "ec2/L-0263D0A3" = 20 # EC2-VPC Elastic IPs
+  }
+  service_code = element(split("/", each.key), 0)
+  quota_code   = element(split("/", each.key), 1)
+  value        = each.value
+}
+
+resource "aws_route53_zone" "zone" {
+  count = var.manage_zone ? 1 : 0
+  name  = var.broker_zone
+}
+

--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -1,3 +1,7 @@
+locals {
+  trusted_aws_account = 133032889584
+}
+
 resource "aws_servicequotas_service_quota" "minimum_quotas" {
   for_each = {
     "vpc/L-45FE3B85" = 20 # egress-only internet gateways per region
@@ -17,5 +21,25 @@ resource "aws_servicequotas_service_quota" "minimum_quotas" {
 resource "aws_route53_zone" "zone" {
   count = var.manage_zone ? 1 : 0
   name  = var.broker_zone
+}
+
+module "iam_assumable_roles" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-roles"
+  version = "~> 4.2.0"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${local.trusted_aws_account}:root",
+  ]
+
+  # Note both of these require MFA by default
+  create_admin_role     = true
+  create_poweruser_role = true
+  admin_role_name       = "ssb-administrator"
+  poweruser_role_name   = "ssb-developer"
+
+  poweruser_role_policy_arns = [
+    "arn:aws:iam::aws:policy/PowerUserAccess",
+  ]
+
 }
 

--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -52,6 +52,14 @@ resource "aws_iam_user_policy_attachment" "eks-broker-policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
 }
 
+# Temporarily give this account the Administrator policy until we can identify
+# the exact set of least-privilege permissions required to operate the EKS
+# broker
+resource "aws_iam_user_policy_attachment" "eks-admin-policy" {
+  user       = module.ssb-eks-broker-user.iam_user_name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
 module "ssb-smtp-broker-user" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
   version = "~> 4.2.0"
@@ -89,4 +97,12 @@ module "smtp_broker_policy" {
 resource "aws_iam_user_policy_attachment" "smtp-broker-policy" {
   user       = module.ssb-smtp-broker-user.iam_user_name
   policy_arn = module.smtp_broker_policy.arn
+}
+
+# Temporarily give this account the Administrator policy until we can identify
+# the exact set of least-privilege permissions required to operate the SMTP
+# broker
+resource "aws_iam_user_policy_attachment" "smtp-admin-policy" {
+  user       = module.ssb-smtp-broker-user.iam_user_name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -43,3 +43,16 @@ module "iam_assumable_roles" {
 
 }
 
+module "ssb-eks-broker-user" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "~> 4.2.0"
+
+  create_iam_user_login_profile = false
+  force_destroy                 = true
+  name                          = "ssb-eks-broker"
+}
+
+resource "aws_iam_user_policy_attachment" "eks-broker-policy" {
+  user       = module.ssb-eks-broker-user.iam_user_name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}

--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -34,13 +34,8 @@ module "iam_assumable_roles" {
   # Note both of these require MFA by default
   create_admin_role     = true
   create_poweruser_role = true
-  admin_role_name       = "ssb-administrator"
-  poweruser_role_name   = "ssb-developer"
-
-  poweruser_role_policy_arns = [
-    "arn:aws:iam::aws:policy/PowerUserAccess",
-  ]
-
+  admin_role_name       = "SSBAdmin"
+  poweruser_role_name   = "SSBDev"
 }
 
 module "ssb-eks-broker-user" {

--- a/s3creds.sh
+++ b/s3creds.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# If you want to use a cloud.gov-brokered S3 broker for your Terraform state,
+# this script makes it easy both to create a service key and to extract the
+# bucket parameters needed for the Terraform backend configuration.
+#
+# If your S3 service instance has a different name, or you want a different key
+# name, edit the following two lines.
+
+SERVICE_INSTANCE_NAME=terraform-s3
+KEY_NAME=terraform-s3-key
+
+cf create-service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}"
+S3_CREDENTIALS=`cf service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}" | tail -n +2`
+
+echo 'Run the following lines at your shell prompt to put the S3 bucket credentials in your environment.'
+echo export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .access_key_id`
+echo export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .secret_access_key`
+echo export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .bucket`
+echo export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.region'`

--- a/terraform.development.tfvars
+++ b/terraform.development.tfvars
@@ -7,4 +7,4 @@ broker_space = {
   space = "development"
 }
 broker_zone = "ssb-dev.datagov.us"
-manage_zone = false
+manage_zone = true

--- a/terraform.development.tfvars
+++ b/terraform.development.tfvars
@@ -1,0 +1,10 @@
+# See vars.tf for more information
+client_spaces = {
+  gsa-datagov = ["development"]
+}
+broker_space = {
+  org   = "gsa-datagov"
+  space = "development"
+}
+broker_zone = "ssb-dev.datagov.us"
+manage_zone = false

--- a/terraform.production.tfvars
+++ b/terraform.production.tfvars
@@ -1,6 +1,6 @@
 # See vars.tf for more information
 client_spaces = {
-  gsa-datagov = ["management", "development", "staging", "prod"]
+  gsa-datagov = ["management", "staging", "prod"]
 }
 broker_space = {
   org   = "gsa-datagov"

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.67"
+      version = "~> 3.35"
     }
   }
 }


### PR DESCRIPTION
This relates to https://github.com/GSA/datagov-deploy/issues/3064.

The accounts created for use by the SSB brokers are provisioned with the `AdministratorAccess` policy attached so that the SSB brokers continue working as they have. A [separate issue](https://github.com/GSA/datagov-ssb/issues/14) covers removing that policy and squinching down the permissions to only the bare necessities.