### PR TITLE
Add TTS' IDVA team as users of the broker

### DIFF
--- a/terraform.production.tfvars
+++ b/terraform.production.tfvars
@@ -1,6 +1,7 @@
 # See vars.tf for more information
 client_spaces = {
-  gsa-datagov = ["management", "staging", "prod"]
+  gsa-datagov = ["management", "staging", "prod"],
+  gsa-tts-identity-prototyping = ["dev", "test", "prod"]
 }
 broker_space = {
   org   = "gsa-datagov"


### PR DESCRIPTION
This draft PR+branch exists as a standing demonstration of the level of effort needed to enable other teams to use the SSB.
- Add them to the file as indicated
- Ask them to add our deployer account as a SpaceDeveloper in all the relevant spaces
- Merge the PR