### PR TITLE
Update CSB and brokerpak versions

### DIFF
--- a/app-setup-eks.sh
+++ b/app-setup-eks.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+CSB_VERSION="0.4.1"
 EKS_BROKERPAK_VERSION="v1.0.0"
 
 # TODO: Check sha256 sums
@@ -24,7 +25,7 @@ EOF
 chmod +x app-eks/.profile
 
 # Add the cloud-service-broker binary
-(cd app-eks && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.4.0/cloud-service-broker.linux) && \
+(cd app-eks && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/${CSB_VERSION}/cloud-service-broker.linux) && \
     chmod +x app-eks/cloud-service-broker
 
 # Add the brokerpak(s)

--- a/app-setup-eks.sh
+++ b/app-setup-eks.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 set -ex
 
-EKS_BROKERPAK_VERSION="v0.29.1"
+EKS_BROKERPAK_VERSION="v1.0.0"
 
 # TODO: Check sha256 sums
-HELM_VERSION="3.2.1"
-KUBECTL_VERSION="1.20.5"
-KUSTOMIZE_VERSION="v3.8.1"
+HELM_VERSION="3.7.1"
+KUBECTL_VERSION="1.22.3"
 
-AWS_IAM_AUTH_VERSION_URL="https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.9/2020-08-04/bin/linux/amd64/aws-iam-authenticator"
+AWS_IAM_AUTH_VERSION_URL="https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator"
 
 BASE_URL="https://get.helm.sh"
 TAR_FILE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
@@ -25,11 +24,11 @@ EOF
 chmod +x app-eks/.profile
 
 # Add the cloud-service-broker binary
-(cd app-eks && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.2.2/cloud-service-broker.linux) && \
+(cd app-eks && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.4.0/cloud-service-broker.linux) && \
     chmod +x app-eks/cloud-service-broker
 
 # Add the brokerpak(s)
-(cd app-eks && curl -f -LO https://github.com/GSA/eks-brokerpak/releases/download/${EKS_BROKERPAK_VERSION}/eks-services-pak-${EKS_BROKERPAK_VERSION}.brokerpak)
+(cd app-eks && curl -f -LO https://github.com/GSA/datagov-brokerpak-eks/releases/download/${EKS_BROKERPAK_VERSION}/datagov-brokerpak-eks-${EKS_BROKERPAK_VERSION}.brokerpak)
 
 # Install the Helm binary
 curl -f -L ${BASE_URL}/${TAR_FILE} |tar xvz && \

--- a/app-setup-smtp.sh
+++ b/app-setup-smtp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-SMTP_BROKERPAK_VERSION="1.0.0"
+SMTP_BROKERPAK_VERSION="v1.1.1"
 
 # Set up an app dir and bin dir
 mkdir -p app-smtp/bin
@@ -15,7 +15,7 @@ EOF
 chmod +x app-smtp/.profile
 
 # Add the cloud-service-broker binary
-(cd app-smtp && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.2.2/cloud-service-broker.linux) && \
+(cd app-smtp && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.4.0/cloud-service-broker.linux) && \
     chmod +x app-smtp/cloud-service-broker
 
 # Add the brokerpak(s)

--- a/app-setup-smtp.sh
+++ b/app-setup-smtp.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+CSB_VERSION="0.4.1"
 SMTP_BROKERPAK_VERSION="v1.1.1"
 
 # Set up an app dir and bin dir
@@ -15,7 +16,7 @@ EOF
 chmod +x app-smtp/.profile
 
 # Add the cloud-service-broker binary
-(cd app-smtp && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.4.0/cloud-service-broker.linux) && \
+(cd app-smtp && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/${CSB_VERSION}/cloud-service-broker.linux) && \
     chmod +x app-smtp/cloud-service-broker
 
 # Add the brokerpak(s)

--- a/app-setup-smtp.sh
+++ b/app-setup-smtp.sh
@@ -19,4 +19,4 @@ chmod +x app-smtp/.profile
     chmod +x app-smtp/cloud-service-broker
 
 # Add the brokerpak(s)
-(cd app-smtp && curl -f -LO https://github.com/GSA/datagov-brokerpak-smtp/releases/download/${SMTP_BROKERPAK_VERSION}/smtp-services-pak-${SMTP_BROKERPAK_VERSION}.brokerpak)
+(cd app-smtp && curl -f -LO https://github.com/GSA/datagov-brokerpak-smtp/releases/download/${SMTP_BROKERPAK_VERSION}/datagov-brokerpak-smtp-${SMTP_BROKERPAK_VERSION}.brokerpak)

--- a/app-setup-solr.sh
+++ b/app-setup-solr.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -ex
 
-DATAGOV_BROKERPAK_VERSION="0.20.0"
+DATAGOV_BROKERPAK_SOLR_VERSION="v1.0.2"
 
 # TODO: Check sha256 sums
-HELM_VERSION="3.2.1"
-KUBECTL_VERSION="1.20.5"
-KUSTOMIZE_VERSION="v3.8.1"
+HELM_VERSION="3.7.1"
+KUBECTL_VERSION="1.22.3"
 
 BASE_URL="https://get.helm.sh"
 TAR_FILE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
@@ -31,11 +30,11 @@ EOF
 chmod +x app-solr/.profile
 
 # Add the cloud-service-broker binary
-(cd app-solr && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.2.2/cloud-service-broker.linux) && \
+(cd app-solr && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.4.0/cloud-service-broker.linux) && \
     chmod +x app-solr/cloud-service-broker
 
 # Add the brokerpak(s)
-(cd app-solr && curl -f -LO https://github.com/GSA/datagov-brokerpak/releases/download/${DATAGOV_BROKERPAK_VERSION}/datagov-services-pak-${DATAGOV_BROKERPAK_VERSION}.brokerpak)
+(cd app-solr && curl -f -LO https://github.com/GSA/datagov-brokerpak-solr/releases/download/${DATAGOV_BROKERPAK_SOLR_VERSION}/datagov-brokerpak-solr-${DATAGOV_BROKERPAK_SOLR_VERSION}.brokerpak)
 
 # Install the Helm binary
 curl -f -L ${BASE_URL}/${TAR_FILE} |tar xvz && \

--- a/app-setup-solr.sh
+++ b/app-setup-solr.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+CSB_VERSION="0.4.1"
 DATAGOV_BROKERPAK_SOLR_VERSION="v1.0.2"
 
 # TODO: Check sha256 sums
@@ -30,7 +31,7 @@ EOF
 chmod +x app-solr/.profile
 
 # Add the cloud-service-broker binary
-(cd app-solr && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/0.4.0/cloud-service-broker.linux) && \
+(cd app-solr && curl -f -L -o cloud-service-broker https://github.com/cloudfoundry-incubator/cloud-service-broker/releases/download/${CSB_VERSION}/cloud-service-broker.linux) && \
     chmod +x app-solr/cloud-service-broker
 
 # Add the brokerpak(s)

--- a/s3creds.sh
+++ b/s3creds.sh
@@ -6,15 +6,17 @@
 #
 # If your S3 service instance has a different name, or you want a different key
 # name, edit the following two lines.
+# 
+# NOTE: This script has been tested with CF CLI v8!
 
 SERVICE_INSTANCE_NAME="${SERVICE_INSTANCE_NAME:-terraform-s3}"
-KEY_NAME="${SERVICE_INSTANCE_NAME}-s3-key"
+KEY_NAME="${SERVICE_INSTANCE_NAME}-key"
 
 cf create-service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}"
 S3_CREDENTIALS=`cf service-key "${SERVICE_INSTANCE_NAME}" "${KEY_NAME}" | tail -n +2`
 
 echo 'Run the following lines at your shell prompt to put the S3 bucket credentials in your environment.'
-echo export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .access_key_id`
-echo export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .secret_access_key`
-echo export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .bucket`
-echo export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.region'`
+echo export AWS_ACCESS_KEY_ID=`echo "${S3_CREDENTIALS}" | jq -r .credentials.access_key_id`
+echo export AWS_SECRET_ACCESS_KEY=`echo "${S3_CREDENTIALS}" | jq -r .credentials.secret_access_key`
+echo export BUCKET_NAME=`echo "${S3_CREDENTIALS}" | jq -r .credentials.bucket`
+echo export AWS_DEFAULT_REGION=`echo "${S3_CREDENTIALS}" | jq -r '.credentials.region'`


### PR DESCRIPTION
The tests won't pass until [this PR](https://github.com/GSA/datagov-brokerpak-solr/pull/27) is merged and a `v1.0.2` release tag is pushed to `datagov-brokerpak-solr`, but I wanted to at least get this PR started as a draft so it can be approved code-wise, and then the tests can be rerun ASAP.

Related to https://github.com/GSA/datagov-deploy/issues/3504