### PR TITLE
Update SMTP brokerpak to 1.1.2

### DIFF
--- a/app-setup-smtp.sh
+++ b/app-setup-smtp.sh
@@ -2,7 +2,7 @@
 set -ex
 
 CSB_VERSION="0.4.1"
-SMTP_BROKERPAK_VERSION="v1.1.1"
+SMTP_BROKERPAK_VERSION="v1.1.2"
 
 # Set up an app dir and bin dir
 mkdir -p app-smtp/bin


### PR DESCRIPTION
This fixes a bug where providing a domain would result in the service provisioning forever.