### PR TITLE
Add IAM policy for persistent volumes

### DIFF
--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -369,6 +369,101 @@ module "eks_brokerpak_pv_policy" {
       {
         "Effect": "Allow",
         "Action": [
+          "ec2:CreateVolume"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateVolume"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/CSIVolumeName": "*"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateVolume"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/kubernetes.io/cluster/*": "owned"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteVolume"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteVolume"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/CSIVolumeName": "*"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteVolume"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/kubernetes.io/cluster/*": "owned"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteSnapshot"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteSnapshot"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+          }
+        }
+      }
+    ]
+  }
   EOF
 }
 

--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -267,6 +267,9 @@ resource "aws_iam_user_policy_attachment" "eks_broker_policies" {
     // AWS EKS brokerpak policy defined below
     "arn:aws:iam::${local.this_aws_account_id}:policy/${module.eks_brokerpak_policy.name}",
 
+    // AWS EKS brokerpak policy for persistent volumes defined below
+    "arn:aws:iam::${local.this_aws_account_id}:policy/${module.eks_brokerpak_pv_policy.name}",
+
     // Uncomment if we are still missing stuff and need to get it working again
     // "arn:aws:iam::aws:policy/AdministratorAccess"
   ])
@@ -305,6 +308,67 @@ module "eks_brokerpak_policy" {
           }
       ]
     }
+  EOF
+}
+
+module "eks_brokerpak_pv_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 4.2.0"
+
+  name        = "eks_brokerpak_pv_policy"
+  path        = "/"
+  description = "Policy granting additional permissions needed by the EKS brokerpak for Persistent Volumes"
+  policy      = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateSnapshot",
+          "ec2:AttachVolume",
+          "ec2:DetachVolume",
+          "ec2:ModifyVolume",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInstances",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeTags",
+          "ec2:DescribeVolumes",
+          "ec2:DescribeVolumesModifications"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateTags"
+        ],
+        "Resource": [
+          "arn:aws:ec2:*:*:volume/*",
+          "arn:aws:ec2:*:*:snapshot/*"
+        ],
+        "Condition": {
+          "StringEquals": {
+            "ec2:CreateAction": [
+              "CreateVolume",
+              "CreateSnapshot"
+            ]
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteTags"
+        ],
+        "Resource": [
+          "arn:aws:ec2:*:*:volume/*",
+          "arn:aws:ec2:*:*:snapshot/*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
   EOF
 }
 


### PR DESCRIPTION
Pull in IAM Policy for Persistent Volumes to solve,
```
Error: Error: release ingress-nginx failed, and has been uninstalled due to atomic being set: timed out waiting for the condition  on ingress.tf line 43, in resource "helm_release" "ingress_nginx":  43: resource "helm_release" "ingress_nginx" {Error: Post "https://881a8176f9449a5358e1e8ade215bfae.sk1.us-west-2.eks.amazonaws.com/apis/storage.k8s.io/v1/storageclasses": dial tcp 44.232.122.77:443: i/o timeout  on persistent-storage.tf line 162, in resource "kubernetes_storage_class" "ebs-sc": 162: resource "kubernetes_storage_class" "ebs-sc" { exit status 1
```