### PR TITLE
Install tools for staging/prod apply

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -26,6 +26,12 @@ jobs:
       TF_VAR_cf_password: ${{ secrets.TF_VAR_cf_password }}
       TF_VAR_aws_access_key_id: ${{ secrets.TF_VAR_aws_access_key_id }}
       TF_VAR_aws_secret_access_key: ${{ secrets.TF_VAR_aws_secret_access_key }}
+      TERRAFORM_PRE_RUN: |
+          ./install-tools.sh
+          cp helm /usr/local/bin/
+          cp kubectl /usr/local/bin/
+          cp aws-iam-authenticator /usr/local/bin/
+          aws-iam-authenticator help
 
     steps:
       - name: checkout
@@ -70,6 +76,12 @@ jobs:
       TF_VAR_cf_password: ${{ secrets.TF_VAR_cf_password }}
       TF_VAR_aws_access_key_id: ${{ secrets.TF_VAR_aws_access_key_id }}
       TF_VAR_aws_secret_access_key: ${{ secrets.TF_VAR_aws_secret_access_key }}
+      TERRAFORM_PRE_RUN: |
+          ./install-tools.sh
+          cp helm /usr/local/bin/
+          cp kubectl /usr/local/bin/
+          cp aws-iam-authenticator /usr/local/bin/
+          aws-iam-authenticator help
 
     steps:
       - name: checkout


### PR DESCRIPTION
Terraform EKS Module needs certain tools to complete its tasks.  We do this in the development `commit` action, but it wasn't copied to the `apply` action.