### PR TITLE
Fix production EKS Cluster Size

### DIFF
--- a/terraform.production.tfvars
+++ b/terraform.production.tfvars
@@ -15,5 +15,5 @@ eks_terraform_subdomain            = "solrcloud-k8s"
 eks_terraform_region               = "us-west-2"
 eks_terraform_instance_name        = "solrcloud"
 eks_terraform_mng_min_capacity     = 1
-eks_terraform_mng_max_capacity     = 14
-eks_terraform_mng_desired_capacity = 14
+eks_terraform_mng_max_capacity     = 40
+eks_terraform_mng_desired_capacity = 40


### PR DESCRIPTION
To accomodate all solr cloud instances, we need a larger eks cluster in production. (production/staging/development solr are all in the same space)