### PR TITLE
Separate AWS and EKS Provision Parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ app-ssb-*.zip
 linux-amd64/
 bin/
 kubeconfig*
+*.log

--- a/application-boundary.tf
+++ b/application-boundary.tf
@@ -72,19 +72,9 @@ data "cloudfoundry_space" "dev-ssb" {
   org  = data.cloudfoundry_org.gsa.id
 }
 
-resource "cloudfoundry_user_provided_service" "ssb-solrcloud-k8s" {
-  name             = "ssb-solrcloud-k8s"
-  space            = data.cloudfoundry_space.dev-ssb.id
-  credentials_json = <<-JSON
-    {
-      "certificate_authority_data": "${module.brokerpak-eks-terraform.certificate_authority_data}",
-      "domain_name": "${module.brokerpak-eks-terraform.domain_name}",
-      "kubeconfig": "${replace(module.brokerpak-eks-terraform.kubeconfig, "\n", "\\n")}",
-      "namespace": "${module.brokerpak-eks-terraform.namespace}",
-      "server": "${module.brokerpak-eks-terraform.server}",
-      "token": "${module.brokerpak-eks-terraform.token}"
-    }
-  JSON
+data "cloudfoundry_user_provided_service" "ssb-solrcloud-k8s" {
+   name             = "ssb-solrcloud-k8s"
+   space            = data.cloudfoundry_space.dev-ssb.id
 }
 
 module "broker_solrcloud" {
@@ -96,7 +86,7 @@ module "broker_solrcloud" {
   client_spaces = var.client_spaces
   enable_ssh    = var.enable_ssh
   # services      = [cloudfoundry_service_instance.solrcloud_broker_k8s_cluster.id]
-  services = [cloudfoundry_user_provided_service.ssb-solrcloud-k8s.id]
+  services = [data.cloudfoundry_user_provided_service.ssb-solrcloud-k8s.id]
 }
 
 module "broker_solr" {

--- a/broker/main.tf
+++ b/broker/main.tf
@@ -26,7 +26,7 @@ resource "cloudfoundry_service_instance" "db" {
 resource "random_uuid" "client_username" {}
 resource "random_password" "client_password" {
   length  = 16
-  special = true
+  special = false
 }
 
 data "archive_file" "app_zip" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3.7'
 
 services:
   terraform:
+    user: 1000:1000
     image: datagov-ssb/terraform:latest
     build:
       context: .
@@ -18,3 +19,5 @@ services:
       - TF_VAR_aws_secret_access_key
       - TF_VAR_cf_username
       - TF_VAR_cf_password
+      - TF_LOG=info
+      - TF_LOG_PATH=terraform.log

--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -6,26 +6,6 @@ locals {
   instructions           = var.manage_zone ? "Create NS and DS records in the ${regex("\\..*", var.broker_zone)} zone with the values indicated." : null
 }
 
-# Static deployment of EKS in the managed boundary. This gets bound to the
-# ssb-solrcloud broker app, and it's where SolrCloud instances are created.
-module "brokerpak-eks-terraform" {
-  source = "github.com/GSA/datagov-brokerpak-eks//terraform?ref=another-fix-for-finding-binaries"
-  providers = {
-    aws                     = aws.eks-terraform
-    aws.dnssec-key-provider = aws.dnssec-key-provider
-  }
-  aws_access_key_id     = module.ssb-eks-broker-user.iam_access_key_id
-  aws_secret_access_key = module.ssb-eks-broker-user.iam_access_key_secret
-  write_kubeconfig      = true
-  subdomain             = var.eks_terraform_subdomain
-  region                = var.eks_terraform_region
-  zone                  = var.broker_zone
-  instance_name         = var.eks_terraform_instance_name
-  mng_min_capacity      = var.eks_terraform_mng_min_capacity
-  mng_max_capacity      = var.eks_terraform_mng_max_capacity
-  mng_desired_capacity  = var.eks_terraform_mng_desired_capacity
-}
-
 data "aws_caller_identity" "current" {}
 
 resource "aws_servicequotas_service_quota" "minimum_quotas" {


### PR DESCRIPTION
We are short-circuiting our release process by using a branch to track the `terraform-driven eks static deployment`.  There are a lot of changes that are happening that are technically effecting our `main` branch directly.  This PR does not have any meaningful commits but it is vastly different from the original version of `main` that was using the older `another-fix-for-finding-binaries`
