### PR TITLE
Fix version tag for cloud-service-broker binary

### DIFF
--- a/app-setup-eks.sh
+++ b/app-setup-eks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-CSB_VERSION="0.10.0"
+CSB_VERSION="v0.10.0"
 EKS_BROKERPAK_VERSION="v1.0.2"
 
 # TODO: Check sha256 sums

--- a/app-setup-smtp.sh
+++ b/app-setup-smtp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-CSB_VERSION="0.10.0"
+CSB_VERSION="v0.10.0"
 SMTP_BROKERPAK_VERSION="v1.1.2"
 
 # Set up an app dir and bin dir

--- a/app-setup-solrcloud.sh
+++ b/app-setup-solrcloud.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 APP_NAME=app-solrcloud
-CSB_VERSION="0.10.0"
+CSB_VERSION="v0.10.0"
 DATAGOV_BROKERPAK_SOLR_VERSION="v1.0.7"
 
 # TODO: Check sha256 sums

--- a/broker/vars.tf
+++ b/broker/vars.tf
@@ -40,7 +40,7 @@ variable "path" {
 }
 
 variable "command" {
-  default     = "source .profile && ./cloud-service-broker serve"
+  default     = "source .profile && /bin/cloud-service-broker serve"
   description = "Command to be run at app startup"
 }
 

--- a/broker/vars.tf
+++ b/broker/vars.tf
@@ -40,7 +40,7 @@ variable "path" {
 }
 
 variable "command" {
-  default     = "source .profile && /bin/cloud-service-broker serve"
+  default     = "source .profile && ./cloud-service-broker serve"
   description = "Command to be run at app startup"
 }
 


### PR DESCRIPTION
Fix for the following error.. @mogul Any context for why we were using a relative path before?

Full traceback: https://github.com/GSA/datagov-ssb/runs/6009707141?check_suite_focus=true
![image](https://user-images.githubusercontent.com/85196563/163211969-e00c461d-feeb-4930-b95f-504f782f41e2.png)

This was caused by the deploy of the last PR, https://github.com/GSA/datagov-ssb/pull/135