### PR TITLE
Increase ssb-solrcloud ram

### DIFF
--- a/application-boundary.tf
+++ b/application-boundary.tf
@@ -81,6 +81,7 @@ module "broker_solrcloud" {
   broker_space  = var.broker_space
   client_spaces = var.client_spaces
   enable_ssh    = var.enable_ssh
+  memory        = 1024
   # services      = [cloudfoundry_service_instance.solrcloud_broker_k8s_cluster.id]
   services = [data.cloudfoundry_user_provided_service.ssb-solrcloud-k8s.id]
 }


### PR DESCRIPTION
Last deployment failed with 137 (out of memory)

Last Run: https://github.com/GSA/datagov-ssb/runs/6761805504?check_suite_focus=true
![image](https://user-images.githubusercontent.com/85196563/172235650-b76d7785-ed41-4e3b-953c-af8926ea58e6.png)
