### PR TITLE
Add pip for solr brokerpak

### DIFF
--- a/app-setup-solrcloud.sh
+++ b/app-setup-solrcloud.sh
@@ -14,6 +14,10 @@ TAR_FILE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
 # Install zip for AWS Lambda restarts of solr
 sudo apt-get -y install zip
 
+# Install pip to install slack_sdk for Slack notifications
+curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+python3 /tmp/get-pip.py
+
 # Set up an app dir and bin dir
 mkdir -p $APP_NAME/bin
 


### PR DESCRIPTION
Related to:
- #160
- #161 
- https://github.com/GSA/data.gov/issues/3904

Needs pip to install slack_sdk python package for slack notifcations.  This is another missing tool that the broker does not have off-the-shelf (just like zip)