### PR TITLE
More missing permissions for Solr Broker User

### DIFF
--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -686,6 +686,8 @@ module "solr_brokerpak_policy" {
         {
           "Effect": "Allow",
           "Action": [
+              "elasticloadbalancing:ModifyLoadBalancerAttributes",
+
               "iam:CreateUser",
               "iam:DeleteUser",
               "iam:GetUser",
@@ -743,7 +745,9 @@ module "solr_brokerpak_policy" {
               "logs:DescribeLogGroups",
               "logs:DeleteLogGroup",
               "logs:ListTagsLogGroup",
-              "logs:PutRetentionPolicy"
+              "logs:PutRetentionPolicy",
+
+              "servicediscovery:ListTagsForResource"
           ],
           "Resource": "*"
         }


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3950
- #166 

Fixes
- `Error: failure configuring LB attributes: AccessDenied: User: ssb-solr-broker is not authorized to perform: elasticloadbalancing:ModifyLoadBalancerAttributes on resource: loadbalancer/app/solr-lb/lb`
- `Error: error listing tags for resource (namespace/ns-solr): AccessDeniedException: User: ssb-solr-broker is not authorized to perform: servicediscovery:ListTagsForResource on resource: servicediscovery:*/*`