### PR TITLE
Solr Broker User Permissions Mark 3

### DIFF
--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -687,6 +687,7 @@ module "solr_brokerpak_policy" {
           "Effect": "Allow",
           "Action": [
               "elasticloadbalancing:ModifyLoadBalancerAttributes",
+              "elasticloadbalancing:DescribeTargetGroupAttributes",
 
               "iam:CreateUser",
               "iam:DeleteUser",


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3950
- #167 

Fixes
- `Error: error retrieving Target Group Attributes: AccessDenied: ssb-solr-broker is not authorized to perform: elasticloadbalancing:DescribeTargetGroupAttributes`