### PR TITLE
Solr Broker User Permission Mark 5

### DIFF
--- a/managed-boundary.tf
+++ b/managed-boundary.tf
@@ -748,7 +748,13 @@ module "solr_brokerpak_policy" {
               "logs:ListTagsLogGroup",
               "logs:PutRetentionPolicy",
 
-              "servicediscovery:ListTagsForResource"
+              "servicediscovery:DeleteNamespace",
+              "servicediscovery:ListTagsForResource",
+
+              "sns:CreateTopic",
+              "sns:DeleteTopic",
+              "sns:ListTopics",
+              "sns:SetTopicAttributes"
           ],
           "Resource": "*"
         }


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3950
- #169 

Fixes
- `Error: error deleting Service Discovery Private DNS Namespace (ns-solr): AccessDeniedException: User: ssb-solr-broker is not authorized to perform: servicediscovery:DeleteNamespace on resource: namespace/ns-solr`
- `failed creating SNS Topic (solr-memory-topic): AuthorizationError: ssb-solr-broker is not authorized to perform: SNS:CreateTopic on resource: solr-memory-topic`

References:
- https://docs.aws.amazon.com/sns/latest/dg/sns-using-identity-based-policies.html