### PR TITLE
Use solr brokerpak version 2.3.0

### DIFF
--- a/app-setup-solr.sh
+++ b/app-setup-solr.sh
@@ -2,7 +2,7 @@
 set -ex
 APP_NAME=app-solr
 CSB_VERSION="v2.5.6"
-DATAGOV_BROKERPAK_SOLR_VERSION="v2.2.0"
+DATAGOV_BROKERPAK_SOLR_VERSION="v2.3.0"
 
 # Install zip for AWS Lambda restarts of solr
 # Install pip to install slack_sdk for Slack notifications


### PR DESCRIPTION
This will deploy the version that we have successfully tested on `development-ssb` into our main `management` broker.